### PR TITLE
feat: 비밀번호 초기화 요청, 비밀번호 초기화 기능 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -3,6 +3,7 @@ import RouteError from './components/RouteError';
 import GeneralLayout from 'components/common/GeneralLayout';
 import Home from 'pages/Home';
 import SignUp from 'pages/SignUp';
+import ResetPassword from 'pages/ResetPassword';
 
 const routerData = [
   {
@@ -17,6 +18,10 @@ const routerData = [
   {
     path: '/signup',
     element: <SignUp />,
+  },
+  {
+    path: '/reset',
+    element: <ResetPassword />,
   },
 ];
 const router = createBrowserRouter(

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,7 +1,17 @@
 import { httpClient } from './http';
 import { SignUpProps } from 'pages/SignUp';
 
-export const SignUp = async (userData: SignUpProps) => {
+export const signUp = async (userData: SignUpProps) => {
   const response = await httpClient.post('/users/join', userData);
+  return response.data;
+};
+
+export const resetRequest = async (data: SignUpProps) => {
+  const response = await httpClient.post('/users/reset', data);
+  return response.data;
+};
+
+export const resetPassword = async (data: SignUpProps) => {
+  const response = await httpClient.put('/users/reset', data);
   return response.data;
 };

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import Title from 'components/common/Title';
+import InputText from 'components/common/InputText';
+import Button from 'components/common/Button';
+import { useAlert } from 'hooks/useAlert';
+import { SignUpStyle } from './SignUp';
+import { resetPassword, resetRequest } from 'api/auth.api';
+
+export interface ResetPasswordProps {
+  email: string;
+  password: string;
+}
+
+const ResetPassword = () => {
+  const navigate = useNavigate();
+  const showAlert = useAlert();
+  const [resetRequested, setResetRequested] = useState<boolean>(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ResetPasswordProps>();
+
+  const onSubmit = (data: ResetPasswordProps) => {
+    if (resetRequested) {
+      // 초기화 함수 호출
+      resetPassword(data).then(() => {
+        showAlert('비밀번호가 초기화 되었습니다.');
+        navigate('/login');
+      });
+    } else {
+      // 초기화 요청 함수 호출
+      resetRequest(data).then(() => {
+        setResetRequested(true);
+      });
+    }
+  };
+  return (
+    <>
+      <Title size="large">비밀번호 초기화</Title>
+      <SignUpStyle>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <fieldset>
+            <InputText placeholder="이메일을 입력하세요" inputType="email" {...register('email')} />
+            {errors.email && <p className="error-text">이메일은 필수로 입력해야합니다.</p>}
+          </fieldset>
+          {resetRequested && (
+            <fieldset>
+              <InputText placeholder="비밀번호를 입력하세요" inputType="password" {...register('password')} />
+              {errors.password && <p className="error-text">비밀번호는 필수로 입력해야합니다.</p>}
+            </fieldset>
+          )}
+
+          <Button buttonType="submit" size="medium" scheme="primary">
+            {resetRequested ? '비밀번호 초기화' : '초기화 요청'}
+          </Button>
+        </form>
+      </SignUpStyle>
+    </>
+  );
+};
+
+export default ResetPassword;

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import Button from 'components/common/Button';
 import InputText from 'components/common/InputText';
 import Title from 'components/common/Title';
-import { SignUp } from 'api/auth.api';
+import { signUp } from 'api/auth.api';
 import { useAlert } from 'hooks/useAlert';
 
 export interface SignUpProps {
@@ -22,7 +22,7 @@ const SignUpPage = () => {
   } = useForm<SignUpProps>();
 
   const onSubmit = (data: SignUpProps) => {
-    SignUp(data)
+    signUp(data)
       .then((res) => {
         showAlert('회원가입이 완료되었습니다.');
         navigate('/login');
@@ -58,7 +58,7 @@ const SignUpPage = () => {
   );
 };
 
-const SignUpStyle = styled.div`
+export const SignUpStyle = styled.div`
   max-width: ${({ theme }) => theme.layout.width.small};
   margin: 80px auto;
   fieldset {


### PR DESCRIPTION
## 비밀번호 초기화 요청, 비밀번호 초기화 기능 구현
### 1. 공통
- signUp 컴포넌트의 스타일을 사용하여 비밀번호 초기화 페이지를 구성
- 라우터에 비밀번호 초기화 페이지 등록

### 2. `resetRequested`를 사용하여 비밀번호 초기화 상태를 관리
- 비밀번호 초기화 요청 이후(`resetRequested = true`)일 때에는 비밀번호를 입력할 수 있는 입력 필드가 추가되고, button의 text도 변경됨

### 3. API:
- auth.api 파일에 `resetRequest`, `resetPassword` 함수 작성
  - `resetRequest`: 서버에 비밀번호 초기화하기 위한 요청을 보냄
  - `resetPassword` : 서버에 비밀번호 초기화(수정) 요청을 보냄