### PR TITLE
feat&refactor: 로그인 페이지 및 로그인 기능 구현, 코드 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "sanitize.css": "^13.0.0",
         "styled-components": "^6.1.8",
         "typescript": "^4.9.5",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^4.5.1"
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
@@ -16112,6 +16113,14 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -17133,6 +17142,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.1.tgz",
+      "integrity": "sha512-XlauQmH64xXSC1qGYNv00ODaQ3B+tNPoy22jv2diYiP4eoDKr9LA+Bh5Bc3gplTrFdb6JVI+N4kc1DZ/tbtfPg==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "sanitize.css": "^13.0.0",
     "styled-components": "^6.1.8",
     "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zustand": "^4.5.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -4,6 +4,7 @@ import GeneralLayout from 'components/common/GeneralLayout';
 import Home from 'pages/Home';
 import SignUp from 'pages/SignUp';
 import ResetPassword from 'pages/ResetPassword';
+import Login from 'pages/Login';
 
 const routerData = [
   {
@@ -18,6 +19,10 @@ const routerData = [
   {
     path: '/signup',
     element: <SignUp />,
+  },
+  {
+    path: '/login',
+    element: <Login />,
   },
   {
     path: '/reset',

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,17 +1,26 @@
+import { AuthData } from 'models/user.model';
 import { httpClient } from './http';
-import { SignUpProps } from 'pages/SignUp';
 
-export const signUp = async (userData: SignUpProps) => {
+export const signUp = async (userData: AuthData) => {
   const response = await httpClient.post('/users/join', userData);
   return response.data;
 };
 
-export const resetRequest = async (data: SignUpProps) => {
+export const resetRequest = async (data: AuthData) => {
   const response = await httpClient.post('/users/reset', data);
   return response.data;
 };
 
-export const resetPassword = async (data: SignUpProps) => {
+export const resetPassword = async (data: AuthData) => {
   const response = await httpClient.put('/users/reset', data);
+  return response.data;
+};
+
+interface LoginResponse {
+  token: string;
+}
+
+export const login = async (userData: AuthData) => {
+  const response = await httpClient.post<LoginResponse>('/users/login', userData);
   return response.data;
 };

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -22,7 +22,6 @@ export const createClient = (config?: AxiosRequestConfig) => {
     },
     (error) => {
       // 로그인 만료 처리
-
       if (error.response.status === 401) {
         removeToken();
         window.location.href = '/login';

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestConfig } from 'axios';
+import { getToken, removeToken } from 'store/auth.store';
 
 const BASE_URL = 'http://localhost:8888';
 const DEFAULT_TIMEOUT = 30000;
@@ -9,6 +10,7 @@ export const createClient = (config?: AxiosRequestConfig) => {
     timeout: DEFAULT_TIMEOUT,
     headers: {
       'Content-Type': 'application/json',
+      Authorization: getToken() ? getToken() : '',
     },
     withCredentials: true,
     ...config,
@@ -19,6 +21,13 @@ export const createClient = (config?: AxiosRequestConfig) => {
       return response;
     },
     (error) => {
+      // 로그인 만료 처리
+
+      if (error.response.status === 401) {
+        removeToken();
+        window.location.href = '/login';
+        return;
+      }
       return Promise.reject(error);
     },
   );

--- a/src/components/AuthForm/AuthInfoBox.tsx
+++ b/src/components/AuthForm/AuthInfoBox.tsx
@@ -1,0 +1,45 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+export type ShowInfoProps = 'login' | 'signup' | null;
+
+const AuthInfoBox = ({ showInfo }: { showInfo: ShowInfoProps }) => {
+  if (!showInfo) return null;
+
+  if (showInfo === 'signup')
+    return (
+      <InfoBoxStyle>
+        <p>
+          이미 계정을 가지고 계신가요?<Link to="/login">로그인</Link>
+        </p>
+      </InfoBoxStyle>
+    );
+
+  return (
+    <InfoBoxStyle>
+      <Link to="/signup">회원가입</Link>
+      <Link to="/reset">비밀번호 초기화</Link>
+    </InfoBoxStyle>
+  );
+};
+
+const InfoBoxStyle = styled.div`
+  margin-top: 20px;
+  display: flex;
+  justify-content: space-between;
+  line-height: 1.5;
+  a {
+    font-size: 0.85rem;
+    text-decoration: none;
+  }
+  p {
+    margin-block-start: 0;
+    font-size: 0.85rem;
+    a {
+      margin-left: 4px;
+      text-decoration: underline;
+    }
+  }
+`;
+
+export default AuthInfoBox;

--- a/src/components/AuthForm/EmailFieldset.tsx
+++ b/src/components/AuthForm/EmailFieldset.tsx
@@ -1,0 +1,19 @@
+import { UseFormRegister, FieldErrors } from 'react-hook-form';
+import { AuthData } from 'models/user.model';
+import InputText from 'components/common/InputText';
+
+export interface FieldsetProps {
+  register: UseFormRegister<AuthData>;
+  errors: FieldErrors<AuthData>;
+}
+
+const EmailFieldset = ({ register, errors }: FieldsetProps) => {
+  return (
+    <fieldset>
+      <InputText placeholder="이메일을 입력하세요" inputType="email" {...register('email', { required: true })} />
+      {errors.email && <p className="error-text">이메일은 필수로 입력해야합니다.</p>}
+    </fieldset>
+  );
+};
+
+export default EmailFieldset;

--- a/src/components/AuthForm/PasswordFieldset.tsx
+++ b/src/components/AuthForm/PasswordFieldset.tsx
@@ -1,0 +1,17 @@
+import InputText from 'components/common/InputText';
+import { FieldsetProps } from './EmailFieldset';
+
+const PasswordFieldset = ({ register, errors }: FieldsetProps) => {
+  return (
+    <fieldset>
+      <InputText
+        placeholder="비밀번호를 입력하세요"
+        inputType="password"
+        {...register('password', { required: true })}
+      />
+      {errors.password && <p className="error-text">비밀번호는 필수로 입력해야합니다.</p>}
+    </fieldset>
+  );
+};
+
+export default PasswordFieldset;

--- a/src/components/AuthForm/index.tsx
+++ b/src/components/AuthForm/index.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from 'styled-components';
+import Button from 'components/common/Button';
+import Title from 'components/common/Title';
+import AuthInfoBox, { ShowInfoProps } from './AuthInfoBox';
+
+interface AuthFormProps {
+  buttonText: string;
+  title: string;
+  onSubmit: () => void;
+  children: React.ReactNode;
+  showInfo: ShowInfoProps;
+}
+
+const AuthForm = ({ showInfo, buttonText, title, onSubmit, children }: AuthFormProps) => {
+  return (
+    <>
+      <AuthFormStyle>
+        <Title size="large" color="text">
+          {title}
+        </Title>
+        <form onSubmit={onSubmit}>
+          {children}
+          <Button buttonType="submit" size="medium" scheme="primary">
+            {buttonText}
+          </Button>
+        </form>
+        <AuthInfoBox showInfo={showInfo} />
+      </AuthFormStyle>
+    </>
+  );
+};
+
+const AuthFormStyle = styled.div`
+  max-width: ${({ theme }) => theme.layout.width.small};
+  margin: 80px auto;
+  fieldset {
+    padding: 0 0 8px 0;
+    border: 0;
+    .error-text {
+      color: tomato;
+    }
+  }
+  h1 {
+    margin-bottom: 30px;
+    text-align: center;
+  }
+  input {
+    width: 100%;
+  }
+  button {
+    width: 100%;
+  }
+`;
+
+export default AuthForm;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -4,9 +4,11 @@ import styled, { css } from 'styled-components';
 import { FaSignInAlt, FaRegUser } from 'react-icons/fa';
 import Logo from './Logo';
 import { useCategory } from 'hooks/useCategory';
+import useAuthStore from 'store/auth.store';
 
 const Header = () => {
   const category = useCategory();
+  const { isLoggedIn, storeLogout } = useAuthStore();
 
   return (
     <HeaderStyle>
@@ -23,18 +25,35 @@ const Header = () => {
       </nav>
       <nav className="auth">
         <ul>
-          <li>
-            <Link to="/login">
-              <FaSignInAlt />
-              로그인
-            </Link>
-          </li>
-          <li>
-            <Link to="/signup">
-              <FaRegUser />
-              회원가입
-            </Link>
-          </li>
+          {isLoggedIn && (
+            <>
+              <li>
+                <Link to="/cart">장바구니</Link>
+              </li>
+              <li>
+                <Link to="/orderlist">주문내역</Link>
+              </li>
+              <li>
+                <button onClick={storeLogout}>로그아웃</button>
+              </li>
+            </>
+          )}
+          {!isLoggedIn && (
+            <>
+              <li>
+                <Link to="/login">
+                  <FaSignInAlt />
+                  로그인
+                </Link>
+              </li>
+              <li>
+                <Link to="/signup">
+                  <FaRegUser />
+                  회원가입
+                </Link>
+              </li>
+            </>
+          )}
         </ul>
       </nav>
     </HeaderStyle>
@@ -42,11 +61,13 @@ const Header = () => {
 };
 
 const NavItemStyle = css`
+  background-color: transparent;
+  border: none;
   color: ${({ theme }) => theme.color.text};
-
   font-weight: 600;
   text-decoration: none;
   transition: all 0.3s;
+  cursor: pointer;
   &:hover {
     color: ${({ theme }) => theme.color.primary};
   }
@@ -79,7 +100,8 @@ const HeaderStyle = styled.header`
       display: flex;
       gap: 16px;
       li {
-        a {
+        a,
+        button {
           ${NavItemStyle}
           font-size: 1rem;
           display: flex;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,77 +1,15 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import styled, { css } from 'styled-components';
-import { FaSignInAlt, FaRegUser } from 'react-icons/fa';
+import styled from 'styled-components';
 import Logo from './Logo';
-import { useCategory } from 'hooks/useCategory';
-import useAuthStore from 'store/auth.store';
+import Nav from './Nav';
 
 const Header = () => {
-  const category = useCategory();
-  const { isLoggedIn, storeLogout } = useAuthStore();
-
   return (
     <HeaderStyle>
       <Logo type="link" size={200} />
-
-      <nav className="category">
-        <ul>
-          {category.map((item) => (
-            <li key={item.id}>
-              <Link to={item.id !== null ? `/books?category_id=${item.id}` : '/books'}>{item.name}</Link>
-            </li>
-          ))}
-        </ul>
-      </nav>
-      <nav className="auth">
-        <ul>
-          {isLoggedIn && (
-            <>
-              <li>
-                <Link to="/cart">장바구니</Link>
-              </li>
-              <li>
-                <Link to="/orderlist">주문내역</Link>
-              </li>
-              <li>
-                <button onClick={storeLogout}>로그아웃</button>
-              </li>
-            </>
-          )}
-          {!isLoggedIn && (
-            <>
-              <li>
-                <Link to="/login">
-                  <FaSignInAlt />
-                  로그인
-                </Link>
-              </li>
-              <li>
-                <Link to="/signup">
-                  <FaRegUser />
-                  회원가입
-                </Link>
-              </li>
-            </>
-          )}
-        </ul>
-      </nav>
+      <Nav />
     </HeaderStyle>
   );
 };
-
-const NavItemStyle = css`
-  background-color: transparent;
-  border: none;
-  color: ${({ theme }) => theme.color.text};
-  font-weight: 600;
-  text-decoration: none;
-  transition: all 0.3s;
-  cursor: pointer;
-  &:hover {
-    color: ${({ theme }) => theme.color.primary};
-  }
-`;
 
 const HeaderStyle = styled.header`
   display: flex;
@@ -82,44 +20,6 @@ const HeaderStyle = styled.header`
   margin: 0 auto;
   padding: 20px 0;
   border-bottom: 1px solid ${({ theme }) => theme.color.background};
-
-  .category {
-    ul {
-      display: flex;
-      gap: 32px;
-      li {
-        a {
-          font-size: 1.5rem;
-          ${NavItemStyle}
-        }
-      }
-    }
-  }
-  .auth {
-    ul {
-      display: flex;
-      gap: 16px;
-      li {
-        a,
-        button {
-          ${NavItemStyle}
-          font-size: 1rem;
-          display: flex;
-          align-items: center;
-          line-height: 1;
-          &:hover {
-            svg {
-              fill: ${({ theme }) => theme.color.primary};
-            }
-          }
-          svg {
-            transition: all 0.3s;
-            margin-right: 6px;
-          }
-        }
-      }
-    }
-  }
 `;
 
 export default Header;

--- a/src/components/common/Logo.tsx
+++ b/src/components/common/Logo.tsx
@@ -17,12 +17,14 @@ const Logo = ({ size, type }: LogoProps) => {
         </Link>
       </LogoStyle>
     );
+
   return (
     <LogoStyle className="logo" size={size}>
       <img src={logoImg} alt="bookstore" />
     </LogoStyle>
   );
 };
+
 const LogoStyle = styled.h1<Omit<LogoProps, 'type'>>`
   img {
     width: ${({ size }) => `${size}px`};

--- a/src/components/common/Nav/AuthNav.tsx
+++ b/src/components/common/Nav/AuthNav.tsx
@@ -1,0 +1,46 @@
+import { Link } from 'react-router-dom';
+import { FaSignInAlt, FaRegUser } from 'react-icons/fa';
+import useAuthStore from 'store/auth.store';
+import { AuthNavStyle } from './Nav.styles';
+
+const AuthNav = () => {
+  const { isLoggedIn, storeLogout } = useAuthStore();
+
+  return (
+    <AuthNavStyle>
+      <ul>
+        {isLoggedIn && (
+          <>
+            <li>
+              <Link to="/cart">장바구니</Link>
+            </li>
+            <li>
+              <Link to="/orderlist">주문내역</Link>
+            </li>
+            <li>
+              <button onClick={storeLogout}>로그아웃</button>
+            </li>
+          </>
+        )}
+        {!isLoggedIn && (
+          <>
+            <li>
+              <Link to="/login">
+                <FaSignInAlt />
+                로그인
+              </Link>
+            </li>
+            <li>
+              <Link to="/signup">
+                <FaRegUser />
+                회원가입
+              </Link>
+            </li>
+          </>
+        )}
+      </ul>
+    </AuthNavStyle>
+  );
+};
+
+export default AuthNav;

--- a/src/components/common/Nav/AuthNav.tsx
+++ b/src/components/common/Nav/AuthNav.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { FaSignInAlt, FaRegUser } from 'react-icons/fa';
+import { FaSignInAlt } from 'react-icons/fa';
 import useAuthStore from 'store/auth.store';
 import { AuthNavStyle } from './Nav.styles';
 
@@ -23,20 +23,12 @@ const AuthNav = () => {
           </>
         )}
         {!isLoggedIn && (
-          <>
-            <li>
-              <Link to="/login">
-                <FaSignInAlt />
-                로그인
-              </Link>
-            </li>
-            <li>
-              <Link to="/signup">
-                <FaRegUser />
-                회원가입
-              </Link>
-            </li>
-          </>
+          <li>
+            <Link to="/login">
+              <FaSignInAlt />
+              로그인
+            </Link>
+          </li>
         )}
       </ul>
     </AuthNavStyle>

--- a/src/components/common/Nav/CategoryNav.tsx
+++ b/src/components/common/Nav/CategoryNav.tsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router-dom';
+import { useCategory } from 'hooks/useCategory';
+import { CategoryNavStyle } from './Nav.styles';
+
+const CategoryNav = () => {
+  const category = useCategory();
+
+  return (
+    <CategoryNavStyle>
+      <ul>
+        {category.map((item) => (
+          <li key={item.id}>
+            <Link to={item.id !== null ? `/books?category_id=${item.id}` : '/books'}>{item.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </CategoryNavStyle>
+  );
+};
+
+export default CategoryNav;

--- a/src/components/common/Nav/Nav.styles.ts
+++ b/src/components/common/Nav/Nav.styles.ts
@@ -1,0 +1,53 @@
+import styled, { css } from 'styled-components';
+
+export const NavItemStyle = css`
+  background-color: transparent;
+  border: none;
+  color: ${({ theme }) => theme.color.text};
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.3s;
+  cursor: pointer;
+  &:hover {
+    color: ${({ theme }) => theme.color.primary};
+  }
+`;
+
+export const AuthNavStyle = styled.nav`
+  ul {
+    display: flex;
+    gap: 16px;
+    li {
+      a,
+      button {
+        ${NavItemStyle}
+        font-size: 1rem;
+        display: flex;
+        align-items: center;
+        line-height: 1;
+        &:hover {
+          svg {
+            fill: ${({ theme }) => theme.color.primary};
+          }
+        }
+        svg {
+          transition: all 0.3s;
+          margin-right: 6px;
+        }
+      }
+    }
+  }
+`;
+
+export const CategoryNavStyle = styled.nav`
+  ul {
+    display: flex;
+    gap: 32px;
+    li {
+      a {
+        font-size: 1.5rem;
+        ${NavItemStyle}
+      }
+    }
+  }
+`;

--- a/src/components/common/Nav/index.tsx
+++ b/src/components/common/Nav/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import AuthNav from './AuthNav';
+import CategoryNav from './CategoryNav';
+
+const Nav = () => {
+  return (
+    <>
+      <CategoryNav />
+      <AuthNav />
+    </>
+  );
+};
+
+export default Nav;

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -2,3 +2,8 @@ export interface User {
   id: number;
   email: string;
 }
+
+export interface AuthData {
+  email: string;
+  password: string;
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -8,6 +8,7 @@ import Title from 'components/common/Title';
 import Button from 'components/common/Button';
 import { AuthData } from 'models/user.model';
 import { login } from 'api/auth.api';
+import useAuthStore from 'store/auth.store';
 
 const Login = () => {
   const navigate = useNavigate();
@@ -18,10 +19,12 @@ const Login = () => {
     formState: { errors },
   } = useForm<AuthData>();
 
+  const { storeLogin } = useAuthStore();
+
   const onSubmit = (data: AuthData) => {
     login(data)
       .then((res) => {
-        console.log(res.token);
+        storeLogin(res.token);
         showAlert('로그인에 성공했습니다.');
         navigate('/');
       })

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
 import { SignUpStyle } from './SignUp';
 import { Link, useNavigate } from 'react-router-dom';
-import { useAlert } from 'hooks/useAlert';
 import { useForm } from 'react-hook-form';
 import InputText from 'components/common/InputText';
 import Title from 'components/common/Title';
 import Button from 'components/common/Button';
+import { useAlert } from 'hooks/useAlert';
 import { AuthData } from 'models/user.model';
 import { login } from 'api/auth.api';
 import useAuthStore from 'store/auth.store';

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,26 +1,26 @@
-import { SignUpStyle } from './SignUp';
-import { Link, useNavigate } from 'react-router-dom';
-import { useForm } from 'react-hook-form';
-import InputText from 'components/common/InputText';
-import Title from 'components/common/Title';
-import Button from 'components/common/Button';
+import { useNavigate } from 'react-router-dom';
 import { useAlert } from 'hooks/useAlert';
 import { AuthData } from 'models/user.model';
 import { login } from 'api/auth.api';
 import useAuthStore from 'store/auth.store';
+import AuthForm from 'components/AuthForm';
+import EmailFieldset from 'components/AuthForm/EmailFieldset';
+import PasswordFieldset from 'components/AuthForm/PasswordFieldset';
+import { useForm } from 'react-hook-form';
 
 const Login = () => {
   const navigate = useNavigate();
   const showAlert = useAlert();
+
+  const { storeLogin } = useAuthStore();
+
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<AuthData>();
 
-  const { storeLogin } = useAuthStore();
-
-  const onSubmit = (data: AuthData) => {
+  const onSubmit = handleSubmit((data: AuthData) => {
     login(data)
       .then((res) => {
         storeLogin(res.token);
@@ -31,28 +31,14 @@ const Login = () => {
         const errorMsg = error.response.data.error.message ?? '로그인에 실패했습니다. 다시 시도 해주세요.';
         showAlert(errorMsg);
       });
-  };
+  });
+
   return (
     <>
-      <Title size="large">로그인</Title>
-      <SignUpStyle>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <fieldset>
-            <InputText placeholder="이메일을 입력하세요" inputType="email" {...register('email')} />
-            {errors.email && <p className="error-text">이메일은 필수로 입력해야합니다.</p>}
-          </fieldset>
-          <fieldset>
-            <InputText placeholder="비밀번호를 입력하세요" inputType="password" {...register('password')} />
-            {errors.password && <p className="error-text">비밀번호는 필수로 입력해야합니다.</p>}
-          </fieldset>
-          <Button buttonType="submit" size="medium" scheme="primary">
-            로그인
-          </Button>
-          <div className="info">
-            <Link to="/reset">비밀번호 초기화</Link>
-          </div>
-        </form>
-      </SignUpStyle>
+      <AuthForm buttonText="로그인" title="로그인" onSubmit={onSubmit} showInfo="login">
+        <EmailFieldset register={register} errors={errors} />
+        <PasswordFieldset register={register} errors={errors} />
+      </AuthForm>
     </>
   );
 };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { SignUpStyle } from './SignUp';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAlert } from 'hooks/useAlert';
+import { useForm } from 'react-hook-form';
+import InputText from 'components/common/InputText';
+import Title from 'components/common/Title';
+import Button from 'components/common/Button';
+import { AuthData } from 'models/user.model';
+import { login } from 'api/auth.api';
+
+const Login = () => {
+  const navigate = useNavigate();
+  const showAlert = useAlert();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<AuthData>();
+
+  const onSubmit = (data: AuthData) => {
+    login(data)
+      .then((res) => {
+        console.log(res.token);
+        showAlert('로그인에 성공했습니다.');
+        navigate('/');
+      })
+      .catch((error) => {
+        const errorMsg = error.response.data.error.message ?? '로그인에 실패했습니다. 다시 시도 해주세요.';
+        showAlert(errorMsg);
+      });
+  };
+  return (
+    <>
+      <Title size="large">로그인</Title>
+      <SignUpStyle>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <fieldset>
+            <InputText placeholder="이메일을 입력하세요" inputType="email" {...register('email')} />
+            {errors.email && <p className="error-text">이메일은 필수로 입력해야합니다.</p>}
+          </fieldset>
+          <fieldset>
+            <InputText placeholder="비밀번호를 입력하세요" inputType="password" {...register('password')} />
+            {errors.password && <p className="error-text">비밀번호는 필수로 입력해야합니다.</p>}
+          </fieldset>
+          <Button buttonType="submit" size="medium" scheme="primary">
+            로그인
+          </Button>
+          <div className="info">
+            <Link to="/reset">비밀번호 초기화</Link>
+          </div>
+        </form>
+      </SignUpStyle>
+    </>
+  );
+};
+
+export default Login;

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,25 +1,25 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
-import Title from 'components/common/Title';
-import InputText from 'components/common/InputText';
-import Button from 'components/common/Button';
 import { useAlert } from 'hooks/useAlert';
-import { SignUpStyle } from './SignUp';
 import { resetPassword, resetRequest } from 'api/auth.api';
 import { AuthData } from 'models/user.model';
+import AuthForm from 'components/AuthForm';
+import EmailFieldset from 'components/AuthForm/EmailFieldset';
+import PasswordFieldset from 'components/AuthForm/PasswordFieldset';
 
 const ResetPassword = () => {
   const navigate = useNavigate();
   const showAlert = useAlert();
   const [resetRequested, setResetRequested] = useState<boolean>(false);
+
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<AuthData>();
 
-  const onSubmit = (data: AuthData) => {
+  const onSubmit = handleSubmit((data: AuthData) => {
     if (resetRequested) {
       // 초기화 함수 호출
       resetPassword(data).then(() => {
@@ -32,29 +32,18 @@ const ResetPassword = () => {
         setResetRequested(true);
       });
     }
-  };
-  return (
-    <>
-      <Title size="large">비밀번호 초기화</Title>
-      <SignUpStyle>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <fieldset>
-            <InputText placeholder="이메일을 입력하세요" inputType="email" {...register('email')} />
-            {errors.email && <p className="error-text">이메일은 필수로 입력해야합니다.</p>}
-          </fieldset>
-          {resetRequested && (
-            <fieldset>
-              <InputText placeholder="비밀번호를 입력하세요" inputType="password" {...register('password')} />
-              {errors.password && <p className="error-text">비밀번호는 필수로 입력해야합니다.</p>}
-            </fieldset>
-          )}
+  });
 
-          <Button buttonType="submit" size="medium" scheme="primary">
-            {resetRequested ? '비밀번호 초기화' : '초기화 요청'}
-          </Button>
-        </form>
-      </SignUpStyle>
-    </>
+  return (
+    <AuthForm
+      buttonText={resetRequested ? '비밀번호 초기화' : '초기화 요청'}
+      title="비밀번호 초기화"
+      onSubmit={onSubmit}
+      showInfo={null}
+    >
+      <EmailFieldset register={register} errors={errors} />
+      {resetRequested && <PasswordFieldset register={register} errors={errors} />}
+    </AuthForm>
   );
 };
 

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -7,11 +7,7 @@ import Button from 'components/common/Button';
 import { useAlert } from 'hooks/useAlert';
 import { SignUpStyle } from './SignUp';
 import { resetPassword, resetRequest } from 'api/auth.api';
-
-export interface ResetPasswordProps {
-  email: string;
-  password: string;
-}
+import { AuthData } from 'models/user.model';
 
 const ResetPassword = () => {
   const navigate = useNavigate();
@@ -21,9 +17,9 @@ const ResetPassword = () => {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<ResetPasswordProps>();
+  } = useForm<AuthData>();
 
-  const onSubmit = (data: ResetPasswordProps) => {
+  const onSubmit = (data: AuthData) => {
     if (resetRequested) {
       // 초기화 함수 호출
       resetPassword(data).then(() => {

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,12 +1,11 @@
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
-import styled from 'styled-components';
-import Button from 'components/common/Button';
-import InputText from 'components/common/InputText';
-import Title from 'components/common/Title';
 import { signUp } from 'api/auth.api';
 import { useAlert } from 'hooks/useAlert';
 import { AuthData } from 'models/user.model';
+import AuthForm from 'components/AuthForm';
+import EmailFieldset from 'components/AuthForm/EmailFieldset';
+import PasswordFieldset from 'components/AuthForm/PasswordFieldset';
 
 const SignUpPage = () => {
   const navigate = useNavigate();
@@ -17,7 +16,7 @@ const SignUpPage = () => {
     formState: { errors },
   } = useForm<AuthData>();
 
-  const onSubmit = (data: AuthData) => {
+  const onSubmit = handleSubmit((data: AuthData) => {
     signUp(data)
       .then((res) => {
         showAlert('회원가입이 완료되었습니다.');
@@ -27,55 +26,16 @@ const SignUpPage = () => {
         const errorMsg = error.response.data[0].msg ?? '회원가입에 실패했습니다. 다시 시도 해주세요.';
         showAlert(errorMsg);
       });
-  };
+  });
 
   return (
     <>
-      <Title size="large">회원가입</Title>
-      <SignUpStyle>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <fieldset>
-            <InputText placeholder="이메일을 입력하세요" inputType="email" {...register('email')} />
-            {errors.email && <p className="error-text">이메일은 필수로 입력해야합니다.</p>}
-          </fieldset>
-          <fieldset>
-            <InputText placeholder="비밀번호를 입력하세요" inputType="password" {...register('password')} />
-            {errors.password && <p className="error-text">비밀번호는 필수로 입력해야합니다.</p>}
-          </fieldset>
-          <Button buttonType="submit" size="medium" scheme="primary">
-            회원가입
-          </Button>
-          <div className="info">
-            <Link to="/reset">비밀번호 초기화</Link>
-          </div>
-        </form>
-      </SignUpStyle>
+      <AuthForm buttonText="회원가입" title="회원가입" onSubmit={onSubmit} showInfo="signup">
+        <EmailFieldset register={register} errors={errors} />
+        <PasswordFieldset register={register} errors={errors} />
+      </AuthForm>
     </>
   );
 };
-
-export const SignUpStyle = styled.div`
-  max-width: ${({ theme }) => theme.layout.width.small};
-  margin: 80px auto;
-  fieldset {
-    padding: 0 0 8px 0;
-    border: 0;
-    .error-text {
-      color: tomato;
-    }
-  }
-
-  input {
-    width: 100%;
-  }
-  button {
-    width: 100%;
-  }
-
-  .info {
-    text-align: center;
-    padding: 16px 0 0 0;
-  }
-`;
 
 export default SignUpPage;

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -6,11 +6,7 @@ import InputText from 'components/common/InputText';
 import Title from 'components/common/Title';
 import { signUp } from 'api/auth.api';
 import { useAlert } from 'hooks/useAlert';
-
-export interface SignUpProps {
-  email: string;
-  password: string;
-}
+import { AuthData } from 'models/user.model';
 
 const SignUpPage = () => {
   const navigate = useNavigate();
@@ -19,9 +15,9 @@ const SignUpPage = () => {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<SignUpProps>();
+  } = useForm<AuthData>();
 
-  const onSubmit = (data: SignUpProps) => {
+  const onSubmit = (data: AuthData) => {
     signUp(data)
       .then((res) => {
         showAlert('회원가입이 완료되었습니다.');

--- a/src/store/auth.store.ts
+++ b/src/store/auth.store.ts
@@ -6,14 +6,14 @@ interface AuthStoreState {
   storeLogout: () => void;
 }
 
-const getToken = () => {
+export const getToken = () => {
   const token = localStorage.getItem('token');
   return token;
 };
 const setToken = (token: string) => {
   localStorage.setItem('token', token);
 };
-const removeToken = () => {
+export const removeToken = () => {
   localStorage.removeItem('token');
 };
 

--- a/src/store/auth.store.ts
+++ b/src/store/auth.store.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+
+interface AuthStoreState {
+  isLoggedIn: boolean;
+  storeLogin: (token: string) => void;
+  storeLogout: () => void;
+}
+
+const getToken = () => {
+  const token = localStorage.getItem('token');
+  return token;
+};
+const setToken = (token: string) => {
+  localStorage.setItem('token', token);
+};
+const removeToken = () => {
+  localStorage.removeItem('token');
+};
+
+const useAuthStore = create<AuthStoreState>((set) => ({
+  isLoggedIn: getToken() ? true : false,
+  storeLogin: (token: string) => {
+    set(() => ({ isLoggedIn: true }));
+    setToken(token);
+  },
+  storeLogout: () => {
+    set(() => ({ isLoggedIn: false }));
+    removeToken();
+  },
+}));
+
+export default useAuthStore;


### PR DESCRIPTION
## 로그인 페이지 및 로그인 기능 구현
- 로그인 여부를 전역관리 하기 위해 zustand 패키지 설치
- 로그인 페이지 라우터에 등록
- 로그인 여부에 따라 auth nav 다른 요소 출력
- 로그아웃 기능 구현
- token이 만료되었을 때 오류 처리 기능 추가

## 리팩토링
### header 안에 nav 모듈화
- header 안 category nav, auth nav 별도의 파일로 분리

### 인증을 위해 사용되는 데이터 타입 모듈화
- AuthData 타입을 별도의 모듈로 분리하여 중복을 제거하고 모듈화함

### 회원관련 폼 모듈화
- 회원가입, 로그인, 비밀번호 초기화 페이지에서 중복된 코드를 줄이기 위해 별도의 파일로 분리함