### PR TITLE
feat: 도서 검색 결과 페이지 생성 및 기능 구현

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -5,6 +5,7 @@ import Home from 'pages/Home';
 import SignUp from 'pages/SignUp';
 import ResetPassword from 'pages/ResetPassword';
 import Login from 'pages/Login';
+import Books from 'pages/Books';
 
 const routerData = [
   {
@@ -14,7 +15,7 @@ const routerData = [
   },
   {
     path: '/books',
-    element: <div>도서목록페이지</div>,
+    element: <Books />,
   },
   {
     path: '/signup',

--- a/src/api/book.api.ts
+++ b/src/api/book.api.ts
@@ -1,0 +1,30 @@
+import { Book } from 'models/book.model';
+import { httpClient } from './http';
+import { Pagination } from 'models/pagination.model';
+
+interface FetchBooksParams {
+  category_id?: number;
+  new?: boolean;
+  current_page?: number;
+  limit?: number;
+}
+
+interface FetchBooksResponse {
+  lists: Book[];
+  pagination: Pagination;
+}
+
+export const fetchBooks = async (params: FetchBooksParams) => {
+  try {
+    const response = await httpClient.get<FetchBooksResponse>('/books', { params });
+    return response.data;
+  } catch (error) {
+    return {
+      lists: [],
+      pagination: {
+        current_page: 1,
+        total_count: 0,
+      },
+    };
+  }
+};

--- a/src/api/book.api.ts
+++ b/src/api/book.api.ts
@@ -5,7 +5,7 @@ import { Pagination } from 'models/pagination.model';
 interface FetchBooksParams {
   category_id?: number;
   new?: boolean;
-  current_page?: number;
+  page?: number;
   limit?: number;
 }
 

--- a/src/components/Books/BookItem.spec.tsx
+++ b/src/components/Books/BookItem.spec.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { BookStoreThemeProvider } from 'context/themeContext';
+import { Book } from 'models/book.model';
+import BooksItem from './BooksItem';
+
+const dummyBook: Book = {
+  id: 1,
+  title: 'Dummy Book',
+  img: 5,
+  category_id: 1,
+  form: 'string',
+  isbn: 'string',
+  summary: 'Dummy summary',
+  detail: 'Dummy detail',
+  author: 'Dummy author',
+  pages: 100,
+  contents: 'string',
+  price: 10000,
+  likes: 1,
+  pub_date: 'string',
+};
+
+describe('Book Item test!', () => {
+  it('렌더 여부', () => {
+    const { getByText, getByAltText } = render(
+      <BookStoreThemeProvider>
+        <BooksItem book={dummyBook} />
+      </BookStoreThemeProvider>,
+    );
+    expect(getByText(dummyBook.title)).toBeInTheDocument();
+    expect(getByText(dummyBook.summary)).toBeInTheDocument();
+    expect(getByText(dummyBook.author)).toBeInTheDocument();
+    expect(getByText('10,000원')).toBeInTheDocument();
+    expect(getByText(dummyBook.likes)).toBeInTheDocument();
+    expect(getByAltText(dummyBook.title)).toHaveAttribute('src', `https://picsum.photos/id/${dummyBook.img}/600/600`);
+  });
+});

--- a/src/components/Books/BookItem.spec.tsx
+++ b/src/components/Books/BookItem.spec.tsx
@@ -24,7 +24,7 @@ describe('Book Item test!', () => {
   it('렌더 여부', () => {
     const { getByText, getByAltText } = render(
       <BookStoreThemeProvider>
-        <BooksItem book={dummyBook} />
+        <BooksItem book={dummyBook} view="grid" />
       </BookStoreThemeProvider>,
     );
     expect(getByText(dummyBook.title)).toBeInTheDocument();

--- a/src/components/Books/BooksEmpty.tsx
+++ b/src/components/Books/BooksEmpty.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const BooksEmpty = () => {
+  return <div>BooksEmpty</div>;
+};
+
+export default BooksEmpty;

--- a/src/components/Books/BooksEmpty.tsx
+++ b/src/components/Books/BooksEmpty.tsx
@@ -1,7 +1,36 @@
 import React from 'react';
+import styled from 'styled-components';
+import { FaSmileWink } from 'react-icons/fa';
+import Title from 'components/common/Title';
+import { Link } from 'react-router-dom';
 
 const BooksEmpty = () => {
-  return <div>BooksEmpty</div>;
+  return (
+    <BooksEmptyStyle>
+      <div className="icon">
+        <FaSmileWink />
+      </div>
+      <Title size="large" color="secondary">
+        검색 결과가 없습니다
+      </Title>
+      <Link to="/books">전체 검색 결과로 이동</Link>
+    </BooksEmptyStyle>
+  );
 };
+
+const BooksEmptyStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 120px 0;
+  .icon {
+    font-size: 4rem;
+    svg {
+      fill: #ccc;
+    }
+  }
+`;
 
 export default BooksEmpty;

--- a/src/components/Books/BooksFilter.tsx
+++ b/src/components/Books/BooksFilter.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const BooksFilter = () => {
+  return <div>BooksFilter</div>;
+};
+
+export default BooksFilter;

--- a/src/components/Books/BooksFilter.tsx
+++ b/src/components/Books/BooksFilter.tsx
@@ -1,7 +1,65 @@
-import React from 'react';
+import { useSearchParams } from 'react-router-dom';
+import styled from 'styled-components';
+import Button from 'components/common/Button';
+import { useCategory } from 'hooks/useCategory';
+import { QUERYSTRING } from 'constance/querystring';
 
 const BooksFilter = () => {
-  return <div>BooksFilter</div>;
+  const category = useCategory();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const handleCategory = (id: number | null) => {
+    const newSearchParams = new URLSearchParams(searchParams);
+
+    if (id === null) {
+      newSearchParams.delete(QUERYSTRING.CATEGORY_ID);
+    } else {
+      newSearchParams.set(QUERYSTRING.CATEGORY_ID, id.toString());
+    }
+    setSearchParams(newSearchParams);
+  };
+
+  const handleNews = () => {
+    const newSearchParams = new URLSearchParams(searchParams);
+
+    if (newSearchParams.get(QUERYSTRING.NEWS)) {
+      newSearchParams.delete(QUERYSTRING.NEWS);
+    } else {
+      newSearchParams.set(QUERYSTRING.NEWS, 'true');
+    }
+    setSearchParams(newSearchParams);
+  };
+
+  return (
+    <BooksFilterStyle>
+      <div className="category">
+        {category.map((item) => (
+          <Button
+            size="medium"
+            scheme={item.isActive ? 'primary' : 'default'}
+            key={item.id}
+            onClick={() => handleCategory(item.id)}
+          >
+            {item.name}
+          </Button>
+        ))}
+      </div>
+      <div className="new">
+        <Button size="medium" scheme={searchParams.get('news') ? 'primary' : 'default'} onClick={() => handleNews()}>
+          신간
+        </Button>
+      </div>
+    </BooksFilterStyle>
+  );
 };
+
+const BooksFilterStyle = styled.div`
+  display: flex;
+  gap: 24px;
+  .category {
+    display: flex;
+    gap: 8px;
+  }
+`;
 
 export default BooksFilter;

--- a/src/components/Books/BooksItem.tsx
+++ b/src/components/Books/BooksItem.tsx
@@ -1,0 +1,21 @@
+import { Book } from 'models/book.model';
+import React from 'react';
+import styled from 'styled-components';
+
+interface BooksItemProps {
+  book: Book;
+}
+
+const BooksItem = ({ book }: BooksItemProps) => {
+  return (
+    <BooksItemStyle>
+      <div>
+        <img src={`https://picsum.photos/id/${book.img}/600/600`} alt={book.title} />
+      </div>
+    </BooksItemStyle>
+  );
+};
+
+const BooksItemStyle = styled.div``;
+
+export default BooksItem;

--- a/src/components/Books/BooksItem.tsx
+++ b/src/components/Books/BooksItem.tsx
@@ -31,6 +31,18 @@ const BooksItem = ({ book, view }: BooksItemProps) => {
   );
 };
 
+/* 2줄 이상일 경우 경우 생략(...) */
+const LimitedParagraph = css`
+  /* Webkit기반 브라우저 동작 */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  /* 모든 브라우저에서 동작 */
+  max-height: 3em;
+  text-overflow: ellipsis;
+`;
+
 const textStyle = css`
   font-size: 0.85rem;
   color: ${({ theme }) => theme.color.secondary};
@@ -55,6 +67,7 @@ const BooksItemStyle = styled.div<{ view: ViewMode }>`
     padding: 16px;
     position: relative;
     .title {
+      ${LimitedParagraph}
       font-size: 1.25rem;
       font-weight: bold;
       margin: 0 0 12px 0;
@@ -64,12 +77,7 @@ const BooksItemStyle = styled.div<{ view: ViewMode }>`
       ${textStyle}
     }
     .summary {
-      display: -webkit-box;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-      -webkit-line-clamp: 2;
-      text-overflow: ellipsis;
-      max-height: 3em;
+      ${LimitedParagraph}
     }
     .price {
       ${textStyle};

--- a/src/components/Books/BooksItem.tsx
+++ b/src/components/Books/BooksItem.tsx
@@ -79,7 +79,7 @@ const BooksItemStyle = styled.div`
     right: 16px;
     bottom: 16px;
     svg {
-      color: ${({ theme }) => theme.color.primary};
+      fill: ${({ theme }) => theme.color.primary};
     }
   }
 `;

--- a/src/components/Books/BooksItem.tsx
+++ b/src/components/Books/BooksItem.tsx
@@ -1,6 +1,9 @@
 import { Book } from 'models/book.model';
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { formatNumber } from 'utils/format';
+import { getImgSrc } from 'utils/image';
+import { FaHeart } from 'react-icons/fa';
 
 interface BooksItemProps {
   book: Book;
@@ -9,13 +12,76 @@ interface BooksItemProps {
 const BooksItem = ({ book }: BooksItemProps) => {
   return (
     <BooksItemStyle>
-      <div>
-        <img src={`https://picsum.photos/id/${book.img}/600/600`} alt={book.title} />
+      <div className="img">
+        <img src={getImgSrc(book.img)} alt={book.title} />
+      </div>
+      <div className="content">
+        <h2 className="title">{book.title}</h2>
+        <p className="summary">{book.summary}</p>
+        <p className="author">{book.author}</p>
+        <p className="price">{formatNumber(book.price)}원</p>
+        <div className="likes">
+          <FaHeart />
+          <span>{book.likes}</span>
+        </div>
       </div>
     </BooksItemStyle>
   );
 };
 
-const BooksItemStyle = styled.div``;
+const textStyle = css`
+  font-size: 0.85rem;
+  color: ${({ theme }) => theme.color.secondary};
+  margin: 0 0 4px 0;
+`;
+
+const BooksItemStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
+  .img {
+    border-radius: ${({ theme }) => theme.borderRadius.default};
+    overflow: hidden;
+    img {
+      max-width: 100%;
+    }
+  }
+  .content {
+    padding: 16px;
+    position: relative;
+    .title {
+      font-size: 1.25rem;
+      font-weight: bold;
+      margin: 0 0 12px 0;
+    }
+    .summary,
+    .author {
+      ${textStyle}
+    }
+    .price {
+      ${textStyle};
+      font-size: 1rem;
+      font-weight: bold;
+    }
+  }
+  .likes {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin: 0 0 4px 0;
+    padding: 4px 12px;
+    border: 1px solid ${({ theme }) => theme.color.border};
+    border-radius: ${({ theme }) => theme.borderRadius.default};
+    font-size: 0%.875rem;
+    font-weight: bold;
+    color: ${({ theme }) => theme.color.primary};
+    position: absolute;
+    right: 16px;
+    bottom: 16px;
+    svg {
+      color: ${({ theme }) => theme.color.primary};
+    }
+  }
+`;
 
 export default BooksItem;

--- a/src/components/Books/BooksItem.tsx
+++ b/src/components/Books/BooksItem.tsx
@@ -4,14 +4,16 @@ import styled, { css } from 'styled-components';
 import { formatNumber } from 'utils/format';
 import { getImgSrc } from 'utils/image';
 import { FaHeart } from 'react-icons/fa';
+import { ViewMode } from './BooksViewSwitcher';
 
 interface BooksItemProps {
   book: Book;
+  view: ViewMode;
 }
 
-const BooksItem = ({ book }: BooksItemProps) => {
+const BooksItem = ({ book, view }: BooksItemProps) => {
   return (
-    <BooksItemStyle>
+    <BooksItemStyle view={view}>
       <div className="img">
         <img src={getImgSrc(book.img)} alt={book.title} />
       </div>
@@ -35,11 +37,13 @@ const textStyle = css`
   margin: 0 0 4px 0;
 `;
 
-const BooksItemStyle = styled.div`
+const BooksItemStyle = styled.div<{ view: ViewMode }>`
   display: flex;
-  flex-direction: column;
+  flex-direction: ${({ view }) => (view === 'grid' ? 'column' : 'row')};
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
   .img {
+    width: ${({ view }) => (view === 'grid' ? 'auto' : '165px')};
+    flex-shrink: 0;
     border-radius: ${({ theme }) => theme.borderRadius.default};
     overflow: hidden;
     img {
@@ -47,6 +51,7 @@ const BooksItemStyle = styled.div`
     }
   }
   .content {
+    flex: ${({ view }) => (view === 'grid' ? 0 : 1)};
     padding: 16px;
     position: relative;
     .title {
@@ -57,6 +62,14 @@ const BooksItemStyle = styled.div`
     .summary,
     .author {
       ${textStyle}
+    }
+    .summary {
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      -webkit-line-clamp: 2;
+      text-overflow: ellipsis;
+      max-height: 3em;
     }
     .price {
       ${textStyle};

--- a/src/components/Books/BooksList.tsx
+++ b/src/components/Books/BooksList.tsx
@@ -1,23 +1,39 @@
 import styled from 'styled-components';
 import { Book } from 'models/book.model';
 import BooksItem from './BooksItem';
+import { useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { QUERYSTRING } from 'constance/querystring';
+import { ViewMode } from './BooksViewSwitcher';
 
 interface BooksListProps {
   list: Book[];
 }
 
 const BooksList = ({ list }: BooksListProps) => {
+  const [view, setView] = useState<ViewMode>('grid');
+  const { search } = useLocation();
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    const viewParam = params.get(QUERYSTRING.VIEW);
+    if (viewParam) {
+      setView(viewParam as ViewMode);
+    }
+  }, [search]);
+
   return (
-    <BookListStyle>
+    <BookListStyle view={view}>
       {list.map((item) => (
-        <BooksItem book={item} key={item.id} />
+        <BooksItem book={item} key={item.id} view={view} />
       ))}
     </BookListStyle>
   );
 };
-const BookListStyle = styled.div`
+
+const BookListStyle = styled.div<{ view: ViewMode }>`
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: ${({ view }) => (view === 'grid' ? 'repeat(4, 1fr)' : 'repeat(1,1fr)')};
   gap: 24px;
 `;
 export default BooksList;

--- a/src/components/Books/BooksList.tsx
+++ b/src/components/Books/BooksList.tsx
@@ -2,29 +2,22 @@ import styled from 'styled-components';
 import { Book } from 'models/book.model';
 import BooksItem from './BooksItem';
 
-const dummyBook: Book = {
-  id: 1,
-  title: 'Dummy Book',
-  img: 5,
-  category_id: 1,
-  form: 'string',
-  isbn: 'string',
-  summary: 'string',
-  detail: 'string',
-  author: 'string',
-  pages: 100,
-  contents: 'string',
-  price: 10000,
-  likes: 1,
-  pub_date: 'string',
-};
+interface BooksListProps {
+  list: Book[];
+}
 
-const BooksList = () => {
+const BooksList = ({ list }: BooksListProps) => {
   return (
     <BookListStyle>
-      <BooksItem book={dummyBook} />
+      {list.map((item) => (
+        <BooksItem book={item} key={item.id} />
+      ))}
     </BookListStyle>
   );
 };
-const BookListStyle = styled.div``;
+const BookListStyle = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 24px;
+`;
 export default BooksList;

--- a/src/components/Books/BooksList.tsx
+++ b/src/components/Books/BooksList.tsx
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+import { Book } from 'models/book.model';
+import BooksItem from './BooksItem';
+
+const dummyBook: Book = {
+  id: 1,
+  title: 'Dummy Book',
+  img: 5,
+  category_id: 1,
+  form: 'string',
+  isbn: 'string',
+  summary: 'string',
+  detail: 'string',
+  author: 'string',
+  pages: 100,
+  contents: 'string',
+  price: 10000,
+  likes: 1,
+  pub_date: 'string',
+};
+
+const BooksList = () => {
+  return (
+    <BookListStyle>
+      <BooksItem book={dummyBook} />
+    </BookListStyle>
+  );
+};
+const BookListStyle = styled.div``;
+export default BooksList;

--- a/src/components/Books/BooksViewSwitcher.tsx
+++ b/src/components/Books/BooksViewSwitcher.tsx
@@ -1,7 +1,54 @@
-import React from 'react';
+import { useSearchParams } from 'react-router-dom';
+import styled from 'styled-components';
+import { FaList, FaTh } from 'react-icons/fa';
+import Button from 'components/common/Button';
+import { QUERYSTRING } from 'constance/querystring';
+import { useEffect } from 'react';
+
+export type ViewMode = 'list' | 'grid';
+
+const viewOptions = [
+  { value: 'list', icon: <FaList /> },
+  { value: 'grid', icon: <FaTh /> },
+];
 
 const BooksViewSwitcher = () => {
-  return <div>BooksViewSwitcher</div>;
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const handleSwitch = (value: ViewMode) => {
+    const newSearchParams = new URLSearchParams(searchParams);
+
+    newSearchParams.set(QUERYSTRING.VIEW, value);
+    setSearchParams(newSearchParams);
+  };
+
+  useEffect(() => {
+    if (!searchParams.get(QUERYSTRING.VIEW)) {
+      handleSwitch('grid');
+    }
+  }, []);
+
+  return (
+    <BookViewSwitcherStyle>
+      {viewOptions.map(({ value, icon }) => (
+        <Button
+          size="medium"
+          scheme={searchParams.get(QUERYSTRING.VIEW) === value ? 'primary' : 'default'}
+          key={value}
+          onClick={() => handleSwitch(value as ViewMode)}
+        >
+          {icon}
+        </Button>
+      ))}
+    </BookViewSwitcherStyle>
+  );
 };
+const BookViewSwitcherStyle = styled.div`
+  display: flex;
+  gap: 8px;
+  svg {
+    fill: #fff;
+  }
+`;
 
 export default BooksViewSwitcher;

--- a/src/components/Books/BooksViewSwitcher.tsx
+++ b/src/components/Books/BooksViewSwitcher.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const BooksViewSwitcher = () => {
+  return <div>BooksViewSwitcher</div>;
+};
+
+export default BooksViewSwitcher;

--- a/src/components/Books/Pagination.tsx
+++ b/src/components/Books/Pagination.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Pagination = () => {
+  return <div>Pagination</div>;
+};
+
+export default Pagination;

--- a/src/components/Books/Pagination.tsx
+++ b/src/components/Books/Pagination.tsx
@@ -1,7 +1,59 @@
-import React from 'react';
+import { useSearchParams } from 'react-router-dom';
+import styled from 'styled-components';
+import Button from 'components/common/Button';
+import { LIMIT } from 'constance/pagination';
+import { Pagination as IPagination } from 'models/pagination.model';
+import { QUERYSTRING } from 'constance/querystring';
 
-const Pagination = () => {
-  return <div>Pagination</div>;
+interface PaginationProps {
+  pagination: IPagination;
+}
+
+const Pagination = ({ pagination }: PaginationProps) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { total_count, current_page } = pagination;
+  const pages: number = Math.ceil(total_count / LIMIT);
+
+  const handleClickPage = (page: number) => {
+    const newSearchParams = new URLSearchParams(searchParams);
+
+    newSearchParams.set(QUERYSTRING.PAGE, page.toString());
+    setSearchParams(newSearchParams);
+  };
+
+  if (pages <= 0) return null;
+  return (
+    <PaginationStyle>
+      {Array(pages)
+        .fill(0)
+        .map((_, idx) => {
+          const pageNum = idx + 1;
+          return (
+            <li key={pageNum}>
+              <Button
+                size="small"
+                scheme={pageNum === Number(current_page) ? 'primary' : 'default'}
+                onClick={() => handleClickPage(pageNum)}
+              >
+                {pageNum}
+              </Button>
+            </li>
+          );
+        })}
+    </PaginationStyle>
+  );
 };
+
+const PaginationStyle = styled.ul`
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  margin: 0;
+  padding: 24px 0;
+  gap: 8px;
+  li {
+    list-style: none;
+  }
+`;
 
 export default Pagination;

--- a/src/components/Books/Pagination.tsx
+++ b/src/components/Books/Pagination.tsx
@@ -24,35 +24,41 @@ const Pagination = ({ pagination }: PaginationProps) => {
   if (pages <= 0) return null;
   return (
     <PaginationStyle>
-      {Array(pages)
-        .fill(0)
-        .map((_, idx) => {
-          const pageNum = idx + 1;
-          return (
-            <li key={pageNum}>
-              <Button
-                size="small"
-                scheme={pageNum === Number(current_page) ? 'primary' : 'default'}
-                onClick={() => handleClickPage(pageNum)}
-              >
-                {pageNum}
-              </Button>
-            </li>
-          );
-        })}
+      <ul>
+        {Array(pages)
+          .fill(0)
+          .map((_, idx) => {
+            const pageNum = idx + 1;
+            return (
+              <li key={pageNum}>
+                <Button
+                  size="small"
+                  scheme={pageNum === Number(current_page) ? 'primary' : 'default'}
+                  onClick={() => handleClickPage(pageNum)}
+                >
+                  {pageNum}
+                </Button>
+              </li>
+            );
+          })}
+      </ul>
     </PaginationStyle>
   );
 };
 
-const PaginationStyle = styled.ul`
+const PaginationStyle = styled.div`
   display: flex;
-  justify-content: start;
+  justify-content: center;
   align-items: center;
-  margin: 0;
   padding: 24px 0;
-  gap: 8px;
-  li {
-    list-style: none;
+  ul {
+    display: flex;
+    margin: 0;
+    padding: 0;
+    gap: 8px;
+    li {
+      list-style: none;
+    }
   }
 `;
 

--- a/src/components/common/Button/Button.spec.tsx
+++ b/src/components/common/Button/Button.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { BookStoreThemeProvider } from '../../../context/themeContext';
+import { BookStoreThemeProvider } from 'context/themeContext';
 import Button from './index';
 
 describe('Button 컴포넌트 테스트', () => {

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -11,9 +11,9 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   buttonType?: 'submit' | 'button';
 }
 
-const Button = ({ children, size, scheme, disabled, isLoading, buttonType = 'button' }: ButtonProps) => {
+const Button = ({ children, size, scheme, disabled, isLoading, buttonType = 'button', ...props }: ButtonProps) => {
   return (
-    <ButtonStyle type={buttonType} size={size} scheme={scheme} disabled={disabled} isLoading={isLoading}>
+    <ButtonStyle type={buttonType} size={size} scheme={scheme} disabled={disabled} isLoading={isLoading} {...props}>
       {children}
     </ButtonStyle>
   );

--- a/src/constance/pagination.ts
+++ b/src/constance/pagination.ts
@@ -1,0 +1,1 @@
+export const LIMIT = 8;

--- a/src/constance/querystring.ts
+++ b/src/constance/querystring.ts
@@ -1,0 +1,4 @@
+export const QUERYSTRING = {
+  CATEGORY_ID: 'category_id',
+  NEWS: 'news',
+};

--- a/src/constance/querystring.ts
+++ b/src/constance/querystring.ts
@@ -1,4 +1,5 @@
 export const QUERYSTRING = {
   CATEGORY_ID: 'category_id',
   NEWS: 'news',
+  PAGE: 'page',
 };

--- a/src/constance/querystring.ts
+++ b/src/constance/querystring.ts
@@ -2,4 +2,5 @@ export const QUERYSTRING = {
   CATEGORY_ID: 'category_id',
   NEWS: 'news',
   PAGE: 'page',
+  VIEW: 'view',
 };

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { fetchBooks } from 'api/book.api';
+import { LIMIT } from 'constance/pagination';
+import { QUERYSTRING } from 'constance/querystring';
+import { Book } from 'models/book.model';
+import { Pagination } from 'models/pagination.model';
+
+export const useBooks = () => {
+  const { search } = useLocation();
+
+  const [books, setBooks] = useState<Book[]>([]);
+  const [pagination, setPagination] = useState<Pagination>({ total_count: 0, current_page: 1 });
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+
+    const categoryIdParams = params.get(QUERYSTRING.CATEGORY_ID);
+    const newsParams = params.get(QUERYSTRING.NEWS);
+    const currentPageParams = params.get(QUERYSTRING.PAGE);
+
+    fetchBooks({
+      category_id: categoryIdParams ? Number(categoryIdParams) : undefined,
+      new: newsParams ? true : undefined,
+      current_page: currentPageParams ? Number(currentPageParams) : 1,
+      limit: LIMIT,
+    }).then((res) => {
+      setBooks(res.lists);
+      setPagination(res.pagination);
+    });
+  }, [search]);
+
+  return { books, pagination };
+};

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -22,7 +22,7 @@ export const useBooks = () => {
     fetchBooks({
       category_id: categoryIdParams ? Number(categoryIdParams) : undefined,
       new: newsParams ? true : undefined,
-      current_page: currentPageParams ? Number(currentPageParams) : 1,
+      page: currentPageParams ? Number(currentPageParams) : 1,
       limit: LIMIT,
     }).then((res) => {
       setBooks(res.lists);

--- a/src/hooks/useCategory.ts
+++ b/src/hooks/useCategory.ts
@@ -1,17 +1,41 @@
 import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { fetchCategory } from 'api/category.api';
 import { CategoryItem } from 'models/category.model';
+import { QUERYSTRING } from 'constance/querystring';
 
 export const useCategory = () => {
+  const { search } = useLocation();
   const [category, setCategory] = useState<CategoryItem[]>([]);
 
+  const setActive = () => {
+    const params = new URLSearchParams(search);
+    const categoryIdParams = params.get(QUERYSTRING.CATEGORY_ID);
+    if (categoryIdParams) {
+      setCategory((prev) => {
+        return prev.map((item) => ({ ...item, isActive: item.id === Number(categoryIdParams) }));
+      });
+    } else {
+      setCategory((prev) => {
+        return prev.map((item) => ({ ...item, isActive: item.id === null }));
+      });
+    }
+  };
+
+  // 최초 렌더시 실행
   useEffect(() => {
     fetchCategory().then((response) => {
       if (!response) return;
       const categoryWithAll = [{ id: null, name: '전체' }, ...response];
       setCategory(categoryWithAll);
+      setActive();
     });
   }, []);
+
+  // url이 변경될 때 setActive 함수 실행
+  useEffect(() => {
+    setActive();
+  }, [search]);
 
   return category;
 };

--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -1,6 +1,7 @@
 export interface CategoryItem {
   id: number | null;
   name: string;
+  isActive?: boolean;
 }
 
 export interface CategoryList {

--- a/src/models/pagination.model.ts
+++ b/src/models/pagination.model.ts
@@ -1,4 +1,4 @@
 export interface Pagination {
   current_page: number;
-  total_page: number;
+  total_count: number;
 }

--- a/src/pages/Books.tsx
+++ b/src/pages/Books.tsx
@@ -6,20 +6,25 @@ import BooksList from 'components/Books/BooksList';
 import BooksViewSwitcher from 'components/Books/BooksViewSwitcher';
 import Pagination from 'components/Books/Pagination';
 import Title from 'components/common/Title';
+import { useBooks } from 'hooks/useBooks';
 
 const Books = () => {
+  const { books, pagination } = useBooks();
+  console.log(books, pagination);
   return (
     <>
       <Title size="large">도서 검색 결과</Title>
       <BookStyle>
         <BooksFilter />
         <BooksViewSwitcher />
-
-        <BooksList />
-
-        <BooksEmpty />
-
-        <Pagination />
+        {books.length > 0 ? (
+          <>
+            <BooksList list={books} />
+            <Pagination />
+          </>
+        ) : (
+          <BooksEmpty />
+        )}
       </BookStyle>
     </>
   );

--- a/src/pages/Books.tsx
+++ b/src/pages/Books.tsx
@@ -15,8 +15,11 @@ const Books = () => {
     <>
       <Title size="large">도서 검색 결과</Title>
       <BookStyle>
-        <BooksFilter />
-        <BooksViewSwitcher />
+        <div className="filter">
+          <BooksFilter />
+          <BooksViewSwitcher />
+        </div>
+
         {books.length > 0 ? (
           <>
             <BooksList list={books} />
@@ -30,6 +33,15 @@ const Books = () => {
   );
 };
 
-const BookStyle = styled.div``;
+const BookStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  .filter {
+    display: flex;
+    justify-content: space-between;
+    padding: 20px 0%;
+  }
+`;
 
 export default Books;

--- a/src/pages/Books.tsx
+++ b/src/pages/Books.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled from 'styled-components';
+import BooksEmpty from 'components/Books/BooksEmpty';
+import BooksFilter from 'components/Books/BooksFilter';
+import BooksList from 'components/Books/BooksList';
+import BooksViewSwitcher from 'components/Books/BooksViewSwitcher';
+import Pagination from 'components/Books/Pagination';
+import Title from 'components/common/Title';
+
+const Books = () => {
+  return (
+    <>
+      <Title size="large">도서 검색 결과</Title>
+      <BookStyle>
+        <BooksFilter />
+        <BooksViewSwitcher />
+
+        <BooksList />
+
+        <BooksEmpty />
+
+        <Pagination />
+      </BookStyle>
+    </>
+  );
+};
+
+const BookStyle = styled.div``;
+
+export default Books;

--- a/src/pages/Books.tsx
+++ b/src/pages/Books.tsx
@@ -23,7 +23,7 @@ const Books = () => {
         {books.length > 0 ? (
           <>
             <BooksList list={books} />
-            <Pagination />
+            <Pagination pagination={pagination} />
           </>
         ) : (
           <BooksEmpty />

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,3 @@
+export const getImgSrc = (id: number) => {
+  return `https://picsum.photos/id/${id}/600/600`;
+};


### PR DESCRIPTION
## 도서 검색 결과 페이지 생성
### 1. 기본 컴포넌트 생성 및 라우터에 등록
### 2. Book Item 컴포넌트 생성
- 도서 리스트에 사용할 아이템 컴포넌트 생성
- Book Item 테스트 코드 작성
### 3. 도서 검색 결과가 없을 때 보여줄 컴포넌트 생성
- Button 컴포넌트 props를 전달하지 않아 이벤트가 실행하지 않은 오류 수정
### 4. 서버에서 도서 목록 가져오는 기능 추가
- 서버와 query 명이 일치하지 않아 데이터를 가져오지 않는 오류 수정
- 도서 결과가 없을 때에는 empty 컴포넌트, 결과가 있다면 list 컴포넌트 렌더하도록 설정
### 5. 도서목록 페이지네이션 구현
- 도서 목록 페이지네이션 기본 컴포넌트 생성
- 페이지를 클릭하면 다음 페이지의 결과를 가져오는 기능 추가
### 6. 검색 결과를 보여주는 view mode를 변경하는 기능 추가
-  view mode를 `grid`, `list` 두 가지로 설정
- view mode가 변경되면 리스트, 아이템 컴포넌트 스타일 변경되도록 수정